### PR TITLE
Restructure project that for minimum dependency as an API client library

### DIFF
--- a/client.go
+++ b/client.go
@@ -204,7 +204,6 @@ func (c *Client) APIReq(v interface{}, method, path string, body interface{}) er
 			marshaled, err = json.Marshal(body)
 		}
 		if err != nil {
-			ExitCode = 1
 			return err
 		}
 

--- a/cmd/arukas/helpers_test.go
+++ b/cmd/arukas/helpers_test.go
@@ -1,4 +1,4 @@
-package arukas
+package main
 
 import (
 	"io"

--- a/cmd/arukas/main.go
+++ b/cmd/arukas/main.go
@@ -1,13 +1,12 @@
 package main
 
 import (
-	arukas "github.com/arukasio/cli"
 	"github.com/joho/godotenv"
 	"os"
 )
 
 func main() {
 	godotenv.Load()
-	exitCode := arukas.Run(os.Args)
+	exitCode := Run(os.Args)
 	os.Exit(exitCode)
 }

--- a/cmd/arukas/ps.go
+++ b/cmd/arukas/ps.go
@@ -1,13 +1,14 @@
-package arukas
+package main
 
 import (
+	arukas "github.com/arukasio/cli"
 	"log"
 )
 
 func listContainers(listAll bool, quiet bool) {
-	var parsedContainer []Container
-	var filteredContainer []Container
-	client := NewClientWithOsExitOnErr()
+	var parsedContainer []arukas.Container
+	var filteredContainer []arukas.Container
+	client := arukas.NewClientWithOsExitOnErr()
 
 	if err := client.Get(&parsedContainer, "/containers"); err != nil {
 		log.Println(err)

--- a/cmd/arukas/ps_test.go
+++ b/cmd/arukas/ps_test.go
@@ -1,4 +1,4 @@
-package arukas
+package main
 
 func ExamplePs() {
 	runCommand([]string{"arukas", "ps"})

--- a/cmd/arukas/rm.go
+++ b/cmd/arukas/rm.go
@@ -1,12 +1,13 @@
-package arukas
+package main
 
 import (
+	arukas "github.com/arukasio/cli"
 	"log"
 )
 
 func removeContainer(containerID string) {
-	client := NewClientWithOsExitOnErr()
-	var container Container
+	client := arukas.NewClientWithOsExitOnErr()
+	var container arukas.Container
 
 	if err := client.Get(&container, "/containers/"+containerID); err != nil {
 		client.Println(nil, "Failed to rm the container")

--- a/cmd/arukas/rm_test.go
+++ b/cmd/arukas/rm_test.go
@@ -1,4 +1,4 @@
-package arukas
+package main
 
 import (
 	"testing"

--- a/cmd/arukas/run.go
+++ b/cmd/arukas/run.go
@@ -1,18 +1,22 @@
-package arukas
+package main
+
+import (
+	arukas "github.com/arukasio/cli"
+)
 
 func createAndRunContainer(name string, image string, instances int, mem int, envs []string, ports []string, cmd string, appName string) {
-	client := NewClientWithOsExitOnErr()
-	var appSet AppSet
+	client := arukas.NewClientWithOsExitOnErr()
+	var appSet arukas.AppSet
 
 	// create an app
-	newApp := App{Name: appName}
+	newApp := arukas.App{Name: appName}
 
-	var parsedEnvs Envs
-	var parsedPorts Ports
+	var parsedEnvs arukas.Envs
+	var parsedPorts arukas.Ports
 
 	if len(envs) > 0 {
 		var err error
-		parsedEnvs, err = ParseEnv(envs)
+		parsedEnvs, err = arukas.ParseEnv(envs)
 		if err != nil {
 			client.Println(nil, err)
 			ExitCode = 1
@@ -22,7 +26,7 @@ func createAndRunContainer(name string, image string, instances int, mem int, en
 
 	if len(ports) > 0 {
 		var err error
-		parsedPorts, err = ParsePort(ports)
+		parsedPorts, err = arukas.ParsePort(ports)
 		if err != nil {
 			client.Println(nil, err)
 			ExitCode = 1
@@ -30,7 +34,7 @@ func createAndRunContainer(name string, image string, instances int, mem int, en
 		}
 	}
 
-	newContainer := Container{
+	newContainer := arukas.Container{
 		Envs:      parsedEnvs,
 		Ports:     parsedPorts,
 		ImageName: image,
@@ -40,7 +44,7 @@ func createAndRunContainer(name string, image string, instances int, mem int, en
 		Name:      name,
 	}
 
-	newAppSet := AppSet{
+	newAppSet := arukas.AppSet{
 		App:       newApp,
 		Container: newContainer,
 	}

--- a/cmd/arukas/run_test.go
+++ b/cmd/arukas/run_test.go
@@ -1,4 +1,4 @@
-package arukas
+package main
 
 func ExampleRun() {
 	runCommand([]string{"arukas", "run", "nginx:latest", "--instances", "1", "--mem", "256", "-p", "80:tcp"})

--- a/cmd/arukas/runner.go
+++ b/cmd/arukas/runner.go
@@ -1,6 +1,7 @@
-package arukas
+package main
 
 import (
+	arukas "github.com/arukasio/cli"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 	"log"
 	"os"
@@ -42,7 +43,7 @@ var (
 // Run arukas
 func Run(args []string) int {
 	kingpin.CommandLine.HelpFlag.Short('h')
-	kingpin.Version(VERSION)
+	kingpin.Version(arukas.VERSION)
 	switch kingpin.MustParse(cli.Parse(args[1:])) {
 	case "ps":
 		listContainers(*psListAll, *psQuiet)

--- a/cmd/arukas/start.go
+++ b/cmd/arukas/start.go
@@ -1,11 +1,12 @@
-package arukas
+package main
 
 import (
+	arukas "github.com/arukasio/cli"
 	"log"
 )
 
 func startContainer(containerID string, quiet bool) {
-	client := NewClientWithOsExitOnErr()
+	client := arukas.NewClientWithOsExitOnErr()
 
 	if err := client.Post(nil, "/containers/"+containerID+"/power", nil); err != nil {
 		client.Println(nil, "Failed to start the container")

--- a/cmd/arukas/start_test.go
+++ b/cmd/arukas/start_test.go
@@ -1,4 +1,4 @@
-package arukas
+package main
 
 import (
 	"testing"

--- a/cmd/arukas/stop.go
+++ b/cmd/arukas/stop.go
@@ -1,11 +1,12 @@
-package arukas
+package main
 
 import (
+	arukas "github.com/arukasio/cli"
 	"log"
 )
 
 func stopContainer(stopContainerID string) {
-	client := NewClientWithOsExitOnErr()
+	client := arukas.NewClientWithOsExitOnErr()
 
 	if err := client.Delete("/containers/" + stopContainerID + "/power"); err != nil {
 		client.Println(nil, "Failed to stop the container")

--- a/cmd/arukas/stop_test.go
+++ b/cmd/arukas/stop_test.go
@@ -1,4 +1,4 @@
-package arukas
+package main
 
 func ExampleStop() {
 	runCommand([]string{"arukas", "stop", "d19b004c-0d59-4f4f-955c-5bace7c49a34"})

--- a/cmd/arukas/version.go
+++ b/cmd/arukas/version.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	arukas "github.com/arukasio/cli"
+)
+
+func displayVersion() {
+	client := arukas.NewClientWithOsExitOnErr()
+	client.Println(nil, arukas.VERSION)
+}

--- a/cmd/arukas/version_test.go
+++ b/cmd/arukas/version_test.go
@@ -1,4 +1,4 @@
-package arukas
+package main
 
 func ExampleVersion() {
 	runCommand([]string{"arukas", "version"})

--- a/version.go
+++ b/version.go
@@ -1,6 +1,0 @@
-package arukas
-
-func displayVersion() {
-	client = NewClientWithOsExitOnErr()
-	client.Println(nil, VERSION)
-}


### PR DESCRIPTION
## What's the problem current?

When using this project as an API client library, it also depends on the CLI dependent libraries(ex.`gopkg.in/alecthomas/kingpin.v2`).

For projects that don't use CLI, is not good to depend on CLI related libraries by importing this project.

## Solution

This problem is occurring because API client and CLI client are in the same package.
So, moving the CLI client to a different package can solve it.

I think that the existing main package is good as moving destination of the CLI client package.

Looking forward to your feedback!
Thanks.